### PR TITLE
Trello #34: Remove link styles from Card component

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -237,6 +237,11 @@ p {
 
 /* Card */
 /* Use .cards to wrap the Card components */
+.productURL {
+  /* Takes off link styles from Card */
+  text-decoration: none;
+  color: inherit;
+}
 .cards {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
Takes of the underlines and blue colour from the Card component texts that came from Link.